### PR TITLE
Fix mandala start date reset

### DIFF
--- a/mandala_agent.py
+++ b/mandala_agent.py
@@ -89,7 +89,10 @@ class MandalaManager:
             if missing_days:
                 # Есть пропуск — сбрасываем
                 await db.execute("DELETE FROM mandala_days WHERE mandala_id=?", (mid,))
-                await db.execute("UPDATE mandalas SET progress=0 WHERE id=?", (mid,))
+                await db.execute(
+                    "UPDATE mandalas SET progress=0, start_date=? WHERE id=?",
+                    (log_dt.isoformat(), mid),
+                )
                 await db.commit()
                 if own: await db.close(); return "reset"
 


### PR DESCRIPTION
## Summary
- update `mandala_agent.log()` to set `start_date` when clearing progress

## Testing
- `python -m py_compile mandala_agent.py db.py mandala.py bot.py charts.py`

------
https://chatgpt.com/codex/tasks/task_e_68403b55bc748332a49891bff8297fec