### PR TITLE
Fix sessions insertion logic

### DIFF
--- a/mandala_agent.py
+++ b/mandala_agent.py
@@ -104,8 +104,8 @@ class MandalaManager:
         if row is None:
             await db.execute("""
                 INSERT INTO mandala_days(mandala_id,date,sessions)
-                VALUES(?,?,1)
-            """, (mid, log_dt.isoformat()))
+                VALUES(?,?,?)
+            """, (mid, log_dt.isoformat(), sessions))
         elif row[0] < sessions:
             await db.execute("""
                 UPDATE mandala_days SET sessions=?


### PR DESCRIPTION
## Summary
- use session count per mode when creating a mandala day record

## Testing
- `python -m py_compile mandala_agent.py bot.py charts.py db.py mandala.py`

------
https://chatgpt.com/codex/tasks/task_e_68403b8050408332ab946833e8cb9eb6