### PR TITLE
Fix README conflict marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,4 @@ If you have additional reference materials for the assistant, you can load them 
 python load_kb.py path/to/articles.csv
 ```
 This step is optional and only needed for the virtual assistant feature.
-=======
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
-
-


### PR DESCRIPTION
## Summary
- remove leftover conflict marker in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842ede4da908332b6e302bdff123bd6