### PR TITLE
Ensure knowledge_base has category column

### DIFF
--- a/db.py
+++ b/db.py
@@ -105,13 +105,24 @@ async def init_db():
 
         """)
         # 👇 Таблица базы знаний для виртуального ассистента
-        await db.execute("""
+        await db.execute(
+            """
             CREATE TABLE IF NOT EXISTS knowledge_base (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                category TEXT NOT NULL,
                 title TEXT NOT NULL,
                 content TEXT NOT NULL
             );
-        """)
+            """
+        )
+
+        # 🛠 авто‑миграция колонки category
+        cur = await db.execute("PRAGMA table_info(knowledge_base)")
+        cols = [row[1] for row in await cur.fetchall()]
+        if "category" not in cols:
+            await db.execute(
+                "ALTER TABLE knowledge_base ADD COLUMN category TEXT NOT NULL DEFAULT ''"
+            )
         await db.commit()
 
     # Создаём отдельную БД знаний

--- a/tests/test_virtual_assistant.py
+++ b/tests/test_virtual_assistant.py
@@ -6,6 +6,7 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import virtual_assistant
+import db
 
 class DummyResp:
     def __init__(self, content):
@@ -23,8 +24,8 @@ class DummyLLM:
 async def test_assistant_ask_includes_context(monkeypatch, tmp_path):
     db_path = tmp_path / "db.sqlite"
     async with aiosqlite.connect(db_path) as db:
-        await db.execute("CREATE TABLE knowledge_base (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, content TEXT)")
-        await db.execute("INSERT INTO knowledge_base (title, content) VALUES ('Yoga', 'Yoga practice info')")
+        await db.execute("CREATE TABLE knowledge_base (id INTEGER PRIMARY KEY AUTOINCREMENT, category TEXT, title TEXT, content TEXT)")
+        await db.execute("INSERT INTO knowledge_base (category, title, content) VALUES ('general', 'Yoga', 'Yoga practice info')")
         await db.commit()
 
     monkeypatch.setattr(virtual_assistant, "DB_PATH", str(db_path))
@@ -42,7 +43,9 @@ async def test_assistant_ask_includes_context(monkeypatch, tmp_path):
 async def test_search_knowledge_empty(monkeypatch, tmp_path):
     db_path = tmp_path / "db.sqlite"
     async with aiosqlite.connect(db_path) as db:
-        await db.execute("CREATE TABLE knowledge_base (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, content TEXT)")
+        await db.execute(
+            "CREATE TABLE knowledge_base (id INTEGER PRIMARY KEY AUTOINCREMENT, category TEXT, title TEXT, content TEXT)"
+        )
         await db.commit()
 
     monkeypatch.setattr(virtual_assistant, "DB_PATH", str(db_path))
@@ -50,3 +53,19 @@ async def test_search_knowledge_empty(monkeypatch, tmp_path):
     assistant = virtual_assistant.VirtualAssistant()
     result = await assistant._search_knowledge("unknown")
     assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_init_db_creates_category_column(monkeypatch, tmp_path):
+    db_path = tmp_path / "main.sqlite"
+    kb_path = tmp_path / "knowledge.sqlite"
+    monkeypatch.setattr(db, "DB_PATH", str(db_path))
+    monkeypatch.setattr(db, "KB_DB_PATH", str(kb_path))
+
+    await db.init_db()
+
+    async with aiosqlite.connect(db_path) as conn:
+        cur = await conn.execute("PRAGMA table_info(knowledge_base)")
+        cols = [row[1] for row in await cur.fetchall()]
+
+    assert "category" in cols


### PR DESCRIPTION
## Summary
- migrate main DB knowledge_base to have a `category` column
- ensure separate KB DB is created from `init_db`
- update assistant tests for new schema
- add regression test verifying `init_db` creates `knowledge_base` with `category`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ee1cffd483329617993a43d759af